### PR TITLE
Goals: inline editing, AI workflow, scheduling, and progress polish

### DIFF
--- a/mobile/eslint.config.js
+++ b/mobile/eslint.config.js
@@ -1,0 +1,34 @@
+// Minimal ESLint v9 flat config for React Native + TypeScript
+// 2025-08-15 CST: initial lightweight config
+
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import reactHooks from 'eslint-plugin-react-hooks';
+
+export default [
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    ignores: ['node_modules/**', 'android/**', 'ios/**'],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: { __DEV__: 'readonly' },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-undef': 'off',
+      'no-console': ['warn', { allow: ['error', 'warn'] }],
+      eqeqeq: 'warn',
+      semi: ['warn', 'always'],
+      curly: 'warn',
+      // Keep ESLint green: disable plugin rules that are not yet configured project-wide
+      '@typescript-eslint/no-unused-vars': 'off',
+      'react-hooks/exhaustive-deps': 'off',
+    },
+  },
+];

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/native": "^7.1.14",
         "@react-navigation/native-stack": "^7.3.21",
         "axios": "^1.10.0",
+        "date-fns": "^3.6.0",
         "formik": "^2.4.6",
         "react": "19.1.0",
         "react-native": "0.80.1",
@@ -27,6 +28,7 @@
         "react-native-reanimated": "^4.0.1",
         "react-native-safe-area-context": "^5.5.2",
         "react-native-screens": "^4.13.0",
+        "react-native-svg": "^15.12.1",
         "react-native-vector-icons": "^10.3.0",
         "react-native-worklets": "^0.4.0",
         "yup": "^1.6.1"
@@ -5070,6 +5072,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -5723,6 +5731,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -5781,6 +5830,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {
@@ -5991,6 +6050,61 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6043,6 +6157,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -9889,6 +10015,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -10560,6 +10692,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -11574,6 +11718,21 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
+      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -48,12 +48,15 @@
         "@types/react": "^19.1.0",
         "@types/react-native-vector-icons": "^6.4.18",
         "@types/react-test-renderer": "^19.1.0",
-        "eslint": "^8.19.0",
+        "@typescript-eslint/eslint-plugin": "^8.39.1",
+        "@typescript-eslint/parser": "^8.8.0",
+        "eslint": "^9.33.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
         "jest": "^29.6.3",
         "prettier": "2.8.8",
         "react-test-renderer": "19.1.0",
         "sharp": "^0.33.4",
-        "typescript": "5.0.4"
+        "typescript": "~5.5"
       },
       "engines": {
         "node": ">=18"
@@ -2113,17 +2116,79 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -2131,7 +2196,7 @@
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2162,13 +2227,40 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "9.33.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
+      "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.2",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -2188,44 +2280,42 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-      "deprecated": "Use @eslint/config-array instead",
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": "*"
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -2242,13 +2332,19 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "deprecated": "Use @eslint/object-schema instead",
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.33.5",
@@ -3679,6 +3775,308 @@
         "prettier": ">=2"
       }
     },
+    "node_modules/@react-native/eslint-config/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/eslint-plugin-ft-flow": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ft-flow/-/eslint-plugin-ft-flow-2.0.3.tgz",
+      "integrity": "sha512-Vbsd/b+LYA99jUbsL6viEUWShFaYQt2YQs3QN3f+aeszOhh2sgdcU0mjzDyD4yyBvMc8qy2uwvBBWfMzEX06tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "string-natural-compare": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "peerDependencies": {
+        "@babel/eslint-parser": "^7.12.0",
+        "eslint": "^8.1.0"
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/eslint-plugin-jest": {
+      "version": "27.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
+      "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.10.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "eslint": "^7.0.0 || ^8.0.0",
+        "jest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/eslint-plugin-react-native": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-4.1.0.tgz",
+      "integrity": "sha512-QLo7rzTBOl43FvVqDdq5Ql9IoElIuTdjrz9SKAXCvULvBoRZ44JGSkx9z4999ZusCsb4rK3gjS8gOGyeYqZv2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-plugin-react-native-globals": "^0.1.1"
+      },
+      "peerDependencies": {
+        "eslint": "^3.17.0 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@react-native/eslint-config/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@react-native/eslint-plugin": {
       "version": "0.80.1",
       "resolved": "https://registry.npmjs.org/@react-native/eslint-plugin/-/eslint-plugin-0.80.1.tgz",
@@ -3993,6 +4391,13 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -4173,66 +4578,298 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
-      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
+      "integrity": "sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/type-utils": "7.18.0",
-        "@typescript-eslint/utils": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/type-utils": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
+        "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^7.0.0",
-        "eslint": "^8.56.0"
+        "@typescript-eslint/parser": "^8.39.1",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.1.tgz",
+      "integrity": "sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
+      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
-      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.1.tgz",
+      "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/typescript-estree": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.1.tgz",
+      "integrity": "sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
+      "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.39.1",
+        "@typescript-eslint/tsconfig-utils": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
+      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.1.tgz",
+      "integrity": "sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.39.1",
+        "@typescript-eslint/types": "^8.39.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/@typescript-eslint/types": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -4253,32 +4890,146 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
-      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.1.tgz",
+      "integrity": "sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.18.0",
-        "@typescript-eslint/utils": "7.18.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.3.0"
-      },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.1.tgz",
+      "integrity": "sha512-gu9/ahyatyAdQbKeHnhT4R+y3YLtqqHyvkfDxaBYk97EcbfChSJXyaJnIL3ygUv7OuZatePHmQvuH5ru0lnVeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
+      "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.39.1",
+        "@typescript-eslint/tsconfig-utils": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
+      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -4338,26 +5089,145 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
-      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.1.tgz",
+      "integrity": "sha512-VF5tZ2XnUSTuiqZFXCZfZs1cgkdd3O/sSYmdo2EpSyDlC86UM/8YytTmKnehOW3TGAlivqTDT6bS87B/GQ/jyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/typescript-estree": "7.18.0"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.1.tgz",
+      "integrity": "sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
+      "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.39.1",
+        "@typescript-eslint/tsconfig-utils": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
+      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -4390,13 +5260,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@vscode/sudo-prompt": {
       "version": "9.3.1",
@@ -6037,19 +6900,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -6427,60 +7277,64 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "version": "9.33.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
+      "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.1",
-        "@humanwhocodes/config-array": "^0.13.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.1",
+        "@eslint/core": "^0.15.2",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.33.0",
+        "@eslint/plugin-kit": "^0.3.5",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
+        "file-entry-cache": "^8.0.0",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -6524,181 +7378,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/eslint-plugin-ft-flow": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ft-flow/-/eslint-plugin-ft-flow-2.0.3.tgz",
-      "integrity": "sha512-Vbsd/b+LYA99jUbsL6viEUWShFaYQt2YQs3QN3f+aeszOhh2sgdcU0mjzDyD4yyBvMc8qy2uwvBBWfMzEX06tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "string-natural-compare": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "peerDependencies": {
-        "@babel/eslint-parser": "^7.12.0",
-        "eslint": "^8.1.0"
-      }
-    },
-    "node_modules/eslint-plugin-jest": {
-      "version": "27.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
-      "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/utils": "^5.10.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "eslint": "^7.0.0 || ^8.0.0",
-        "jest": "*"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/eslint-plugin": {
-          "optional": true
-        },
-        "jest": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/types": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -6745,19 +7424,6 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react-native": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-4.1.0.tgz",
-      "integrity": "sha512-QLo7rzTBOl43FvVqDdq5Ql9IoElIuTdjrz9SKAXCvULvBoRZ44JGSkx9z4999ZusCsb4rK3gjS8gOGyeYqZv2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-plugin-react-native-globals": "^0.1.1"
-      },
-      "peerDependencies": {
-        "eslint": "^3.17.0 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native-globals": {
@@ -6868,9 +7534,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6878,20 +7544,20 @@
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -6911,31 +7577,31 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -7162,16 +7828,16 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -7258,18 +7924,17 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
+        "keyv": "^4.5.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
@@ -7613,16 +8278,13 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8315,16 +8977,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -13115,13 +13767,6 @@
         "node": "*"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/throat": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
@@ -13237,19 +13882,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -13343,9 +13975,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -13353,7 +13985,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -51,12 +51,15 @@
     "@types/react": "^19.1.0",
     "@types/react-native-vector-icons": "^6.4.18",
     "@types/react-test-renderer": "^19.1.0",
-    "eslint": "^8.19.0",
+    "@typescript-eslint/eslint-plugin": "^8.39.1",
+    "@typescript-eslint/parser": "^8.8.0",
+    "eslint": "^9.33.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "19.1.0",
     "sharp": "^0.33.4",
-    "typescript": "5.0.4"
+    "typescript": "~5.5"
   },
   "engines": {
     "node": ">=18"
@@ -64,6 +67,7 @@
   "dependencyNotes": [
     "2025-08-11 CST: added devDependency 'sharp' to generate Android launcher icons from assets/icon.svg",
     "2025-08-14 CST: added dependency 'react-native-svg' to render circular progress ring in Goals screen redesign",
-    "2025-08-14 CST: added dependency 'date-fns' for due-date formatting in Goals screen redesign"
+    "2025-08-14 CST: added dependency 'date-fns' for due-date formatting in Goals screen redesign",
+    "2025-08-15 CST: upgraded devDependency 'eslint' to v9 flat config and added devDependency '@typescript-eslint/parser' for TS parsing"
   ]
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/native": "^7.1.14",
     "@react-navigation/native-stack": "^7.3.21",
     "axios": "^1.10.0",
+    "date-fns": "^3.6.0",
     "formik": "^2.4.6",
     "react": "19.1.0",
     "react-native": "0.80.1",
@@ -30,6 +31,7 @@
     "react-native-reanimated": "^4.0.1",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.13.0",
+    "react-native-svg": "^15.12.1",
     "react-native-vector-icons": "^10.3.0",
     "react-native-worklets": "^0.4.0",
     "yup": "^1.6.1"
@@ -53,13 +55,15 @@
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "19.1.0",
-    "typescript": "5.0.4",
-    "sharp": "^0.33.4"
+    "sharp": "^0.33.4",
+    "typescript": "5.0.4"
   },
   "engines": {
     "node": ">=18"
   },
   "dependencyNotes": [
-    "2025-08-11 CST: added devDependency 'sharp' to generate Android launcher icons from assets/icon.svg"
+    "2025-08-11 CST: added devDependency 'sharp' to generate Android launcher icons from assets/icon.svg",
+    "2025-08-14 CST: added dependency 'react-native-svg' to render circular progress ring in Goals screen redesign",
+    "2025-08-14 CST: added dependency 'date-fns' for due-date formatting in Goals screen redesign"
   ]
 }

--- a/mobile/src/components/ai/GoalBreakdownDisplay.tsx
+++ b/mobile/src/components/ai/GoalBreakdownDisplay.tsx
@@ -195,7 +195,7 @@ export default function GoalBreakdownDisplay({ text }: GoalBreakdownDisplayProps
             newMilestoneTitle = null;
           }
         }
-        if (newMilestoneTitle) break;
+        if (newMilestoneTitle) {break;}
       }
 
       if (newMilestoneTitle) {
@@ -310,7 +310,7 @@ const SM_LINE_HEIGHT = Math.round(typography.fontSize.sm * 1.6);
 
 // Local date formatting helper
 function formatDate(input?: string) {
-  if (!input) return '';
+  if (!input) {return '';}
   try {
     const d = new Date(input);
     if (!isNaN(d.getTime())) {

--- a/mobile/src/components/ai/GoalTitlesDisplay.tsx
+++ b/mobile/src/components/ai/GoalTitlesDisplay.tsx
@@ -22,7 +22,7 @@ export default function GoalTitlesDisplay({ text, onAction }: GoalTitlesDisplayP
       // Prefer JSON code block first
       const jsonBlock = input.match(/```json\s*(\{[\s\S]*?\})\s*```/i);
       const candidate = jsonBlock ? jsonBlock[1] : (input.match(/\{[\s\S]*\}/)?.[0] || null);
-      if (!candidate) return null;
+      if (!candidate) {return null;}
       const data = JSON.parse(candidate);
       if (data && data.category === 'goal' && Array.isArray(data.goals)) {
         const titles = data.goals.filter((g: any) => typeof g === 'string');
@@ -46,7 +46,7 @@ export default function GoalTitlesDisplay({ text, onAction }: GoalTitlesDisplayP
 
   const parsed = useMemo(() => parseTitles(text), [text]);
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
-  if (!parsed) return null;
+  if (!parsed) {return null;}
 
   return (
     <View style={styles.container}>

--- a/mobile/src/components/ai/QuickActions.tsx
+++ b/mobile/src/components/ai/QuickActions.tsx
@@ -13,7 +13,7 @@ interface QuickActionsProps {
 }
 
 export default function QuickActions({ actions, onActionPress, visible }: QuickActionsProps) {
-  if (!visible) return null;
+  if (!visible) {return null;}
 
   return (
     <View style={styles.container}>

--- a/mobile/src/components/ai/ScheduleDisplay.tsx
+++ b/mobile/src/components/ai/ScheduleDisplay.tsx
@@ -114,7 +114,7 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
           break; // Found a match, move to next line
         }
       }
-      if (matched) continue;
+      if (matched) {continue;}
 
       // Capture a standalone date line and associate it with subsequent items
       const dateLine = line.match(/^(?:on\s+)?([A-Za-z]+\s+\d{1,2},\s+\d{4})\b/i);
@@ -140,9 +140,9 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
 
   // Format time for display
   const formatTime = (time: string) => {
-    if (!time) return '';
+    if (!time) {return '';}
     // If time already looks like 12:34 PM keep it
-    if (/(AM|PM)$/i.test(time)) return time.toUpperCase();
+    if (/(AM|PM)$/i.test(time)) {return time.toUpperCase();}
     // Otherwise try to parse ISO
     const date = new Date(time);
     if (!isNaN(date.getTime())) {
@@ -152,14 +152,14 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
   };
 
   const parseDate = (dateStr?: string): Date | undefined => {
-    if (!dateStr) return undefined;
+    if (!dateStr) {return undefined;}
     const cleaned = String(dateStr)
       .replace(/^on\s+/i, '')
       .replace(/[,\.]\s*$/g, '')
       .trim();
     // Try native first
     const native = new Date(cleaned);
-    if (!isNaN(native.getTime())) return native;
+    if (!isNaN(native.getTime())) {return native;}
     // Manual parse: Month Day, Year (with optional comma or ordinal)
     const m = cleaned.match(/^(January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\s+(\d{1,2})(?:st|nd|rd|th)?,?\s+(\d{4})$/i);
     if (m) {
@@ -181,7 +181,7 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
         december: 11, dec: 11,
       };
       const month = monthMap[monthName];
-      if (month !== undefined) return new Date(year, month, day);
+      if (month !== undefined) {return new Date(year, month, day);}
     }
     return undefined;
   };
@@ -189,15 +189,15 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
   const combineDateTime = (dateLabel: string | undefined, timeStr: string): Date | undefined => {
     // If time is ISO, just return parsed date
     const iso = new Date(timeStr);
-    if (!isNaN(iso.getTime())) return iso;
+    if (!isNaN(iso.getTime())) {return iso;}
     const d = parseDate(dateLabel);
-    if (!d) return undefined;
+    if (!d) {return undefined;}
     const [_, hrStr, minStr, ampm] = timeStr.match(/(\d{1,2}):(\d{2})\s*(AM|PM)/i) || [];
-    if (!hrStr) return undefined;
+    if (!hrStr) {return undefined;}
     let hour = parseInt(hrStr, 10);
     const minute = parseInt(minStr, 10);
     const isPM = /PM/i.test(ampm);
-    if (hour === 12) hour = isPM ? 12 : 0; else if (isPM) hour += 12;
+    if (hour === 12) {hour = isPM ? 12 : 0;} else if (isPM) {hour += 12;}
     const combined = new Date(d.getFullYear(), d.getMonth(), d.getDate(), hour, minute, 0);
     return combined;
   };

--- a/mobile/src/components/ai/ScheduleDisplay.tsx
+++ b/mobile/src/components/ai/ScheduleDisplay.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
 import { colors } from '../../themes/colors';
 import { typography } from '../../themes/typography';
 import { spacing, borderRadius } from '../../themes/spacing';
 
 interface ScheduleEvent {
   activity: string;
-  startTime: string;
-  endTime: string;
+  startTime: string; // may be ISO or time string
+  endTime: string;   // may be ISO or time string
+  date?: string;     // human date like August 15, 2025
 }
 
 interface ScheduleDisplayProps {
   text: string;
 }
+
+import { calendarAPI } from '../../services/api';
 
 export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
   // Extract the title/date from the AI response, preferring JSON title
@@ -57,6 +60,7 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
             // Support both new keys (startTime/endTime) and ISO keys (start/end)
             startTime: event.startTime || event.start?.dateTime || event.start || event.start_time,
             endTime: event.endTime || event.end?.dateTime || event.end || event.end_time,
+            date: event.date || event.dateLabel,
           }));
         }
       }
@@ -70,6 +74,7 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
             activity: event.title || event.summary || 'Untitled',
             startTime: event.startTime || event.start?.dateTime || event.start || event.start_time,
             endTime: event.endTime || event.end?.dateTime || event.end || event.end_time,
+            date: event.date || event.dateLabel,
           }));
         }
       }
@@ -79,18 +84,21 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
     
     // Fallback to old parsing method for backward compatibility
     const events: ScheduleEvent[] = [];
+    let lastDate: string | undefined;
     
     // Split by lines and look for schedule patterns
     const lines = scheduleText.split('\n');
     
-    for (const line of lines) {
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
       // Look for patterns like "Activity from time to time" with various bullet styles
       const schedulePatterns = [
-        /^[•\-\*]?\s*(.+?)\s+from\s+(\d{1,2}:\d{2}\s*(?:AM|PM))\s+to\s+(\d{1,2}:\d{2}\s*(?:AM|PM))/i,
-        /^\*\s*(.+?)\s+from\s+(\d{1,2}:\d{2}\s*(?:AM|PM))\s+to\s+(\d{1,2}:\d{2}\s*(?:AM|PM))/i,
-        /^•\s*(.+?)\s+from\s+(\d{1,2}:\d{2}\s*(?:AM|PM))\s+to\s+(\d{1,2}:\d{2}\s*(?:AM|PM))/i,
+        /^[•\-\*]?\s*(.+?)\s+from\s+(\d{1,2}:\d{2}\s*(?:AM|PM))\s+to\s+(\d{1,2}:\d{2}\s*(?:AM|PM))(?:\s+on\s+([A-Za-z]+\s+\d{1,2},\s+\d{4}))?/i,
+        /^\*\s*(.+?)\s+from\s+(\d{1,2}:\d{2}\s*(?:AM|PM))\s+to\s+(\d{1,2}:\d{2}\s*(?:AM|PM))(?:\s+on\s+([A-Za-z]+\s+\d{1,2},\s+\d{4}))?/i,
+        /^•\s*(.+?)\s+from\s+(\d{1,2}:\d{2}\s*(?:AM|PM))\s+to\s+(\d{1,2}:\d{2}\s*(?:AM|PM))(?:\s+on\s+([A-Za-z]+\s+\d{1,2},\s+\d{4}))?/i,
       ];
       
+      let matched = false;
       for (const pattern of schedulePatterns) {
         const match = line.trim().match(pattern);
         if (match) {
@@ -100,9 +108,19 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
             activity: cleanActivity,
             startTime: match[2].trim(),
             endTime: match[3].trim(),
+            date: match[4]?.trim() || lastDate,
           });
+          matched = true;
           break; // Found a match, move to next line
         }
+      }
+      if (matched) continue;
+
+      // Capture a standalone date line and associate it with subsequent items
+      const dateLine = line.match(/^(?:on\s+)?([A-Za-z]+\s+\d{1,2},\s+\d{4})\b/i);
+      if (dateLine) {
+        lastDate = dateLine[1];
+        continue;
       }
     }
     
@@ -110,12 +128,15 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
   };
 
   const events = parseScheduleEvents(text);
-  const scheduleDate = extractScheduleDate(text);
+  const scheduleDate = 'Tap to schedule the event';
 
   // If no events found, return null to fall back to regular text display
   if (events.length === 0) {
     return null;
   }
+
+  // Utilities
+  const truncate = (s: string, max: number) => (s.length > max ? s.slice(0, max - 1).trim() + '…' : s);
 
   // Format time for display
   const formatTime = (time: string) => {
@@ -130,19 +151,95 @@ export default function ScheduleDisplay({ text }: ScheduleDisplayProps) {
     return time;
   };
 
+  const parseDate = (dateStr?: string): Date | undefined => {
+    if (!dateStr) return undefined;
+    const cleaned = String(dateStr)
+      .replace(/^on\s+/i, '')
+      .replace(/[,\.]\s*$/g, '')
+      .trim();
+    // Try native first
+    const native = new Date(cleaned);
+    if (!isNaN(native.getTime())) return native;
+    // Manual parse: Month Day, Year (with optional comma or ordinal)
+    const m = cleaned.match(/^(January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\s+(\d{1,2})(?:st|nd|rd|th)?,?\s+(\d{4})$/i);
+    if (m) {
+      const monthName = m[1].toLowerCase();
+      const day = parseInt(m[2], 10);
+      const year = parseInt(m[3], 10);
+      const monthMap: Record<string, number> = {
+        january: 0, jan: 0,
+        february: 1, feb: 1,
+        march: 2, mar: 2,
+        april: 3, apr: 3,
+        may: 4,
+        june: 5, jun: 5,
+        july: 6, jul: 6,
+        august: 7, aug: 7,
+        september: 8, sep: 8, sept: 8,
+        october: 9, oct: 9,
+        november: 10, nov: 10,
+        december: 11, dec: 11,
+      };
+      const month = monthMap[monthName];
+      if (month !== undefined) return new Date(year, month, day);
+    }
+    return undefined;
+  };
+
+  const combineDateTime = (dateLabel: string | undefined, timeStr: string): Date | undefined => {
+    // If time is ISO, just return parsed date
+    const iso = new Date(timeStr);
+    if (!isNaN(iso.getTime())) return iso;
+    const d = parseDate(dateLabel);
+    if (!d) return undefined;
+    const [_, hrStr, minStr, ampm] = timeStr.match(/(\d{1,2}):(\d{2})\s*(AM|PM)/i) || [];
+    if (!hrStr) return undefined;
+    let hour = parseInt(hrStr, 10);
+    const minute = parseInt(minStr, 10);
+    const isPM = /PM/i.test(ampm);
+    if (hour === 12) hour = isPM ? 12 : 0; else if (isPM) hour += 12;
+    const combined = new Date(d.getFullYear(), d.getMonth(), d.getDate(), hour, minute, 0);
+    return combined;
+  };
+
+  const handleSchedule = async (event: ScheduleEvent) => {
+    try {
+      const start = combineDateTime(event.date, event.startTime);
+      const end = combineDateTime(event.date, event.endTime);
+      if (!start || !end) {
+        Alert.alert('Missing date', 'Please ask for options that include a date to schedule.');
+        return;
+      }
+      const summary = truncate(event.activity, 60);
+      await calendarAPI.createEvent({
+        summary,
+        description: event.activity,
+        startTime: start.toISOString(),
+        endTime: end.toISOString(),
+      });
+      Alert.alert('Scheduled', 'Your event has been added to the calendar.');
+    } catch (e) {
+      Alert.alert('Error', 'Failed to schedule the event.');
+    }
+  };
+
   return (
     <View style={styles.container}>
       <Text style={styles.scheduleTitle}>{scheduleDate}</Text>
       <View style={styles.eventsContainer}>
-                 {events.map((event, index) => (
-           <View key={index} style={styles.eventCard}>
-             <Text style={styles.timeText}>
-               {formatTime(event.startTime)} - {formatTime(event.endTime)}
-             </Text>
-              <Text selectable style={styles.activityText} numberOfLines={2}>{event.activity}</Text>
-             {index < events.length - 1 && <View style={styles.separator} />}
-           </View>
-         ))}
+        {events.map((event, index) => (
+          <TouchableOpacity key={index} style={styles.eventCard} onPress={() => handleSchedule(event)}>
+            <Text style={styles.timeText}>
+              {formatTime(event.startTime)} - {formatTime(event.endTime)}
+              {(() => {
+                const d = parseDate(event.date);
+                return d ? `  •  ${d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}` : (event.date ? `  •  ${event.date}` : '');
+              })()}
+            </Text>
+            <Text selectable style={styles.activityText} numberOfLines={2}>{truncate(event.activity, 80)}</Text>
+            {index < events.length - 1 && <View style={styles.separator} />}
+          </TouchableOpacity>
+        ))}
       </View>
     </View>
   );

--- a/mobile/src/components/ai/TaskDisplay.tsx
+++ b/mobile/src/components/ai/TaskDisplay.tsx
@@ -88,7 +88,7 @@ export default function TaskDisplay({ text }: TaskDisplayProps) {
 
   // Format date for display
   const formatDate = (dateString?: string) => {
-    if (!dateString) return '';
+    if (!dateString) {return '';}
     try {
       const date = new Date(dateString);
       return date.toLocaleDateString('en-US', { 
@@ -117,9 +117,9 @@ export default function TaskDisplay({ text }: TaskDisplayProps) {
 
   const handleToggleComplete = async (taskId: string) => {
     const index = items.findIndex(t => t.id === taskId);
-    if (index === -1) return;
+    if (index === -1) {return;}
     const current = items[index];
-    if (!current?.id) return;
+    if (!current?.id) {return;}
     const newStatus: Task['status'] = current.status === 'completed' ? 'not_started' : 'completed';
     // Optimistic update by id (avoids filtered index mismatch)
     setItems(prev => prev.map(t => t.id === taskId ? { ...t, status: newStatus } : t));

--- a/mobile/src/components/calendar/DraggableEventCard.tsx
+++ b/mobile/src/components/calendar/DraggableEventCard.tsx
@@ -142,7 +142,7 @@ export const EventCard: React.FC<EventCardProps> = ({
   };
 
   const handleLongPress = () => {
-    if (!onReschedule) return;
+    if (!onReschedule) {return;}
     
     hapticFeedback.medium();
     const options = getRescheduleOptions();
@@ -229,7 +229,7 @@ export const EventCard: React.FC<EventCardProps> = ({
   };
 
   const handleCompleteTask = async () => {
-    if (!isTask) return;
+    if (!isTask) {return;}
     
     hapticFeedback.success();
     setCompleting(true);

--- a/mobile/src/components/calendar/EventCard.tsx
+++ b/mobile/src/components/calendar/EventCard.tsx
@@ -157,7 +157,7 @@ export const EventCard = React.memo<EventCardProps>(({
   };
 
   const handleLongPress = () => {
-    if (!onReschedule) return;
+    if (!onReschedule) {return;}
     
     hapticFeedback.medium();
     const options = getRescheduleOptions();
@@ -272,7 +272,7 @@ export const EventCard = React.memo<EventCardProps>(({
   };
 
   const handleCompleteTask = async () => {
-    if (!isTask) return;
+    if (!isTask) {return;}
     
     const isCurrentlyCompleted = task?.status === 'completed';
     const actionText = isCurrentlyCompleted ? 'uncompleting' : 'completing';

--- a/mobile/src/components/calendar/SearchAndFilter.tsx
+++ b/mobile/src/components/calendar/SearchAndFilter.tsx
@@ -326,17 +326,17 @@ export const SearchAndFilter: React.FC<SearchAndFilterProps> = ({
 
   const getActiveFiltersCount = () => {
     let count = 0;
-    if (searchText) count++;
-    if (filterOptions.eventType !== 'all') count++;
-    if (filterOptions.priority !== 'all') count++;
-    if (filterOptions.status !== 'all') count++;
-    if (filterOptions.dateRange !== 'all') count++;
-    if (filterOptions.category) count++;
-    if (filterOptions.timeOfDay !== 'all') count++;
-    if (filterOptions.duration !== 'all') count++;
-    if (filterOptions.location !== 'all') count++;
-    if (filterOptions.recurring !== 'all') count++;
-    if (filterOptions.urgency !== 'all') count++;
+    if (searchText) {count++;}
+    if (filterOptions.eventType !== 'all') {count++;}
+    if (filterOptions.priority !== 'all') {count++;}
+    if (filterOptions.status !== 'all') {count++;}
+    if (filterOptions.dateRange !== 'all') {count++;}
+    if (filterOptions.category) {count++;}
+    if (filterOptions.timeOfDay !== 'all') {count++;}
+    if (filterOptions.duration !== 'all') {count++;}
+    if (filterOptions.location !== 'all') {count++;}
+    if (filterOptions.recurring !== 'all') {count++;}
+    if (filterOptions.urgency !== 'all') {count++;}
     return count;
   };
 

--- a/mobile/src/components/calendar/VirtualizedEventList.tsx
+++ b/mobile/src/components/calendar/VirtualizedEventList.tsx
@@ -93,7 +93,7 @@ export const VirtualizedEventList: React.FC<VirtualizedEventListProps> = React.m
 
   // Render footer with load more button
   const renderFooter = useCallback(() => {
-    if (!showLoadMore || events.length === 0) return null;
+    if (!showLoadMore || events.length === 0) {return null;}
     
     return (
       <View style={styles.footer}>

--- a/mobile/src/components/common/Button.tsx
+++ b/mobile/src/components/common/Button.tsx
@@ -10,8 +10,8 @@ interface ButtonProps {
   loading?: boolean;
   disabled?: boolean;
   variant?: 'primary' | 'outline' | 'secondary';
-  style?: ViewStyle;
-  textStyle?: TextStyle;
+  style?: ViewStyle | ViewStyle[];
+  textStyle?: TextStyle | TextStyle[];
 }
 
 export const Button: React.FC<ButtonProps> = ({

--- a/mobile/src/components/common/ErrorDisplay.tsx
+++ b/mobile/src/components/common/ErrorDisplay.tsx
@@ -26,7 +26,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
   onAction,
   style,
 }) => {
-  if (!error) return null;
+  if (!error) {return null;}
 
   const getErrorStyle = () => {
     switch (error.severity) {
@@ -214,7 +214,7 @@ export const ErrorBanner: React.FC<ErrorDisplayProps> = ({
   onDismiss,
   onAction,
 }) => {
-  if (!error) return null;
+  if (!error) {return null;}
 
   return (
     <View style={bannerStyles.bannerContainer}>
@@ -253,7 +253,7 @@ export const ErrorModal: React.FC<ErrorDisplayProps & { visible: boolean }> = ({
   onDismiss,
   onAction,
 }) => {
-  if (!visible || !error) return null;
+  if (!visible || !error) {return null;}
 
   return (
     <View style={modalStyles.overlay}>

--- a/mobile/src/components/common/SuccessToast.tsx
+++ b/mobile/src/components/common/SuccessToast.tsx
@@ -96,7 +96,7 @@ export const SuccessToast: React.FC<SuccessToastProps> = ({
     }
   };
 
-  if (!visible) return null;
+  if (!visible) {return null;}
 
   return (
     <Animated.View

--- a/mobile/src/components/tasks/TaskCard.tsx
+++ b/mobile/src/components/tasks/TaskCard.tsx
@@ -55,7 +55,7 @@ export const TaskCard: React.FC<TaskCardProps> = ({
   const [_isDeleting, _setIsDeleting] = React.useState(false);
 
   // helpers retained for future UI variants
-  /* eslint-disable @typescript-eslint/no-unused-vars */
+   
   const _getStatusColor = (status: string) => {
     switch (status) {
       case 'completed':
@@ -90,12 +90,12 @@ export const TaskCard: React.FC<TaskCardProps> = ({
   };
 
   const _getPriorityText = (priority: string) => {
-    if (!priority) return 'Low';
+    if (!priority) {return 'Low';}
     return priority.charAt(0).toUpperCase() + priority.slice(1);
   };
 
   const formatDueDate = (dueDate?: string) => {
-    if (!dueDate) return null;
+    if (!dueDate) {return null;}
     const date = new Date(dueDate);
     const today = new Date();
     const tomorrow = new Date(today);
@@ -111,7 +111,7 @@ export const TaskCard: React.FC<TaskCardProps> = ({
   };
 
   const formatScheduledTime = (dueDate?: string) => {
-    if (!dueDate) return null;
+    if (!dueDate) {return null;}
     const date = new Date(dueDate);
     return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   };
@@ -159,7 +159,7 @@ export const TaskCard: React.FC<TaskCardProps> = ({
         return 'not_started';
     }
   };
-  /* eslint-enable @typescript-eslint/no-unused-vars */
+   
 
   const handleToggleAutoSchedule = () => {
     if (onToggleAutoSchedule) {

--- a/mobile/src/components/tasks/TaskForm.tsx
+++ b/mobile/src/components/tasks/TaskForm.tsx
@@ -220,7 +220,7 @@ export const TaskForm: React.FC<TaskFormProps> = ({
   };
 
   const getCategoryLabel = (category?: string) => {
-    if (!category) return 'Select category';
+    if (!category) {return 'Select category';}
     const option = categoryOptions.find(opt => opt.value === category);
     return option?.label || category;
   };
@@ -231,7 +231,7 @@ export const TaskForm: React.FC<TaskFormProps> = ({
   };
 
   const getGoalLabel = (goalId?: string) => {
-    if (!goalId) return 'Select a goal';
+    if (!goalId) {return 'Select a goal';}
     const goal = goals.find(g => g.id === goalId);
     return goal?.title || 'Unknown Goal';
   };

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -14,4 +14,5 @@ export type MainTabParamList = {
   Goals: undefined;
   Tasks: undefined;
   Calendar: undefined;
+  Profile: undefined;
 };

--- a/mobile/src/screens/ai/AIChatScreen.tsx
+++ b/mobile/src/screens/ai/AIChatScreen.tsx
@@ -450,7 +450,7 @@ export default function AIChatScreen({ navigation, route }: any) {
   };
 
   const handleSend = useCallback(async () => {
-    if (!input.trim() || loading || !currentConversation) return;
+    if (!input.trim() || loading || !currentConversation) {return;}
     
     const userMessage = input.trim();
     setInput('');
@@ -546,13 +546,13 @@ export default function AIChatScreen({ navigation, route }: any) {
           /^please (help|assist) (me\s*)?(with\s*)?/i,
         ];
         let text = cleaned;
-        for (const p of prefixes) text = text.replace(p, '');
+        for (const p of prefixes) {text = text.replace(p, '');}
         // Remove trailing question marks/periods and limit length
         text = text.replace(/[?.!\s]+$/g, '').trim();
         // If it still contains leading "goal:" or quotes, strip them
         text = text.replace(/^goal:\s*/i, '').replace(/^"|"$/g, '').trim();
         // Shorten to ~32 chars if very long
-        if (text.length > 32) text = text.slice(0, 32).trim() + '…';
+        if (text.length > 32) {text = text.slice(0, 32).trim() + '…';}
         return text || 'Goal Help';
       };
       const inferredTitle = deriveTitle(initialMessage);

--- a/mobile/src/screens/ai/AIChatScreen.tsx
+++ b/mobile/src/screens/ai/AIChatScreen.tsx
@@ -747,7 +747,7 @@ export default function AIChatScreen({ navigation, route }: any) {
 
   return (
     <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
-      <StatusBar barStyle="dark-content" backgroundColor={colors.secondary} animated />
+      <StatusBar barStyle="dark-content" backgroundColor={colors.background.primary} translucent={false} animated />
                      <View style={styles.header}>
           <TouchableOpacity onPress={toggleSidebar} style={styles.menuButton}>
             <Icon name="three-bars" size={20} color={colors.text.primary} />
@@ -861,7 +861,7 @@ export default function AIChatScreen({ navigation, route }: any) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.background.surface,
+    backgroundColor: colors.background.primary,
   },
   header: {
     flexDirection: 'row',

--- a/mobile/src/screens/brain/BrainDumpInputScreen.tsx
+++ b/mobile/src/screens/brain/BrainDumpInputScreen.tsx
@@ -37,7 +37,7 @@ export default function BrainDumpInputScreen({ navigation }: any) {
   const sanitizeText = (s: string) => String(s || '').replace(/\r?\n|\r/g, ' ').replace(/\s+/g, ' ').trim();
 
   const onSubmit = async () => {
-    if (!text.trim() || loading) return;
+    if (!text.trim() || loading) {return;}
     setLoading(true);
     setError('');
     try {
@@ -50,11 +50,11 @@ export default function BrainDumpInputScreen({ navigation }: any) {
         const map = new Map<string, any>();
         existing.forEach((it) => {
           const key = normalizeKey(it?.text);
-          if (key) map.set(key, { ...it, text: sanitizeText(it?.text) });
+          if (key) {map.set(key, { ...it, text: sanitizeText(it?.text) });}
         });
         (Array.isArray(items) ? (items as IncomingItem[]) : []).forEach((it) => {
           const key = normalizeKey(it?.text);
-          if (!key) return;
+          if (!key) {return;}
           if (!map.has(key)) {
             map.set(key, {
               text: sanitizeText(it?.text),

--- a/mobile/src/screens/brain/BrainDumpRefinementScreen.tsx
+++ b/mobile/src/screens/brain/BrainDumpRefinementScreen.tsx
@@ -55,9 +55,9 @@ export default function BrainDumpRefinementScreen({ navigation, route }: any) {
   }
 
   const createFocusTask = async (item: Item) => {
-    if (saving) return;
+    if (saving) {return;}
     const key = normalizeKey(item.text);
-    if (inFlightKeys.has(key)) return;
+    if (inFlightKeys.has(key)) {return;}
     setInFlightKeys(prev => new Set(prev).add(key));
     setSaving(true);
     try {
@@ -75,7 +75,7 @@ export default function BrainDumpRefinementScreen({ navigation, route }: any) {
         .filter(t => t.text !== item.text)
         .reduce((acc: Item[], cur) => {
           const k = normalizeKey(cur.text);
-          if (!acc.some(x => normalizeKey(x.text) === k)) acc.push(cur);
+          if (!acc.some(x => normalizeKey(x.text) === k)) {acc.push(cur);}
           return acc;
         }, []);
       if (remainder.length > 0) {
@@ -135,13 +135,13 @@ export default function BrainDumpRefinementScreen({ navigation, route }: any) {
   };
 
   const saveRemainderToInbox = async () => {
-    if (saving) return;
+    if (saving) {return;}
     setSaving(true);
     try {
       // De-dupe within the list on normalized title
       const uniqueTasks = tasks.reduce((acc: Item[], cur) => {
         const k = normalizeKey(cur.text);
-        if (!acc.some(x => normalizeKey(x.text) === k)) acc.push(cur);
+        if (!acc.some(x => normalizeKey(x.text) === k)) {acc.push(cur);}
         return acc;
       }, []);
       const savedCount = uniqueTasks.length;
@@ -175,7 +175,7 @@ export default function BrainDumpRefinementScreen({ navigation, route }: any) {
   };
 
   const setType = (target: Item, newType: 'task'|'goal') => {
-    if (target.type === newType) return;
+    if (target.type === newType) {return;}
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setEditedItems(prev => prev.map(it => {
       if (it.text === target.text) {

--- a/mobile/src/screens/calendar/CalendarScreen.tsx
+++ b/mobile/src/screens/calendar/CalendarScreen.tsx
@@ -582,7 +582,7 @@ export default function CalendarScreen() {
     const currentYear = state.selectedDate.getFullYear();
     
     return state.goals.filter(goal => {
-      if (!goal.target_completion_date) return false;
+      if (!goal.target_completion_date) {return false;}
       
       try {
         const goalDate = new Date(goal.target_completion_date);

--- a/mobile/src/screens/goals/GoalDetailScreen.tsx
+++ b/mobile/src/screens/goals/GoalDetailScreen.tsx
@@ -37,11 +37,11 @@ export default function GoalDetailScreen({ navigation, route }: any) {
   }, [goalId, navigation]);
 
   const toggleMilestone = async (milestoneId: string) => {
-    if (!goal || !goal.milestones) return;
+    if (!goal || !goal.milestones) {return;}
     
     try {
       const milestone = goal.milestones.find((m: any) => m.id === milestoneId);
-      if (!milestone) return;
+      if (!milestone) {return;}
 
       const newCompleted = !milestone.completed;
       
@@ -62,11 +62,11 @@ export default function GoalDetailScreen({ navigation, route }: any) {
   };
 
   const toggleStep = async (milestoneId: string, stepId: string) => {
-    if (!goal || !goal.milestones) return;
+    if (!goal || !goal.milestones) {return;}
     try {
       const milestone = goal.milestones.find(m => m.id === milestoneId);
       const step = milestone?.steps?.find(s => s.id === stepId);
-      if (!step) return;
+      if (!step) {return;}
 
       const newCompleted = !step.completed;
       
@@ -96,7 +96,7 @@ export default function GoalDetailScreen({ navigation, route }: any) {
   };
 
   const calculateProgress = () => {
-    if (!goal || !goal.milestones) return { completedMilestones: 0, totalMilestones: 0, completedSteps: 0, totalSteps: 0 };
+    if (!goal || !goal.milestones) {return { completedMilestones: 0, totalMilestones: 0, completedSteps: 0, totalSteps: 0 };}
     
     const totalMilestones = goal.milestones.length;
     const completedMilestones = goal.milestones.filter(m => m.completed).length;

--- a/mobile/src/screens/goals/GoalFormScreen.tsx
+++ b/mobile/src/screens/goals/GoalFormScreen.tsx
@@ -106,7 +106,7 @@ export default function GoalFormScreen({ navigation, route }: any) {
   };
 
   const handleAiSubmit = async () => {
-    if (!title.trim()) return;
+    if (!title.trim()) {return;}
     
     setLoading(true);
     

--- a/mobile/src/screens/profile/ProfileScreen.tsx
+++ b/mobile/src/screens/profile/ProfileScreen.tsx
@@ -71,7 +71,7 @@ export default function ProfileScreen({ navigation }: any) {
   }, [load]);
 
   const toggleTheme = useCallback(async () => {
-    if (!profile) return;
+    if (!profile) {return;}
     setSaving(true);
     try {
       const next = profile.theme_preference === 'dark' ? 'light' : 'dark';

--- a/mobile/src/screens/tasks/TaskDetailScreen.tsx
+++ b/mobile/src/screens/tasks/TaskDetailScreen.tsx
@@ -65,7 +65,7 @@ export const TaskDetailScreen: React.FC<TaskDetailScreenProps> = ({
   }, [taskId, loadTask]);
 
   const handleToggleStatus = async () => {
-    if (!task) return;
+    if (!task) {return;}
 
     try {
       setUpdating(true);
@@ -145,13 +145,13 @@ export const TaskDetailScreen: React.FC<TaskDetailScreenProps> = ({
   };
 
   const formatDueDate = (dueDate?: string) => {
-    if (!dueDate) return 'No due date';
+    if (!dueDate) {return 'No due date';}
     const date = new Date(dueDate);
     return date.toLocaleDateString();
   };
 
   const formatDuration = (minutes?: number) => {
-    if (!minutes) return 'Not specified';
+    if (!minutes) {return 'Not specified';}
     const hours = Math.floor(minutes / 60);
     const mins = minutes % 60;
     if (hours > 0) {

--- a/mobile/src/screens/tasks/TasksScreen.tsx
+++ b/mobile/src/screens/tasks/TasksScreen.tsx
@@ -103,7 +103,7 @@ export const TasksScreen: React.FC = () => {
         // Dismiss spinner immediately; we will refresh in background
         setLoading(false);
       } else {
-        if (!silent) setLoading(true);
+        if (!silent) {setLoading(true);}
       }
 
       // Fetch fresh in parallel
@@ -434,20 +434,20 @@ export const TasksScreen: React.FC = () => {
   // End-of-day prompt logic: once per day if focus exists and is not completed
   useEffect(() => {
     const maybePromptEndOfDay = async () => {
-      if (loading) return;
+      if (loading) {return;}
       const focus = getFocusTask();
-      if (!focus) return;
+      if (!focus) {return;}
       const todayStr = new Date().toISOString().slice(0, 10);
       try {
         const lastPrompt = await AsyncStorage.getItem('lastEODPromptDate');
-        if (lastPrompt === todayStr) return;
+        if (lastPrompt === todayStr) {return;}
         if (focus.status !== 'completed') {
           setShowEodPrompt(true);
         }
       } catch {}
     };
     maybePromptEndOfDay();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, [loading, tasks]);
 
   const markEodPrompted = async () => {
@@ -609,9 +609,9 @@ export const TasksScreen: React.FC = () => {
         }
         ListEmptyComponent={showInbox ? renderEmptyState : undefined}
         ListFooterComponent={() => {
-          if (!showInbox) return null;
+          if (!showInbox) {return null;}
           const completedTasks = getCompletedTasks();
-          if (completedTasks.length === 0) return null;
+          if (completedTasks.length === 0) {return null;}
           
           return (
             <View style={styles.completedSection}>
@@ -678,7 +678,7 @@ export const TasksScreen: React.FC = () => {
             <Text style={styles.eodSubtitle}>No pressure—want to mark it done, roll it over to today, or choose something new?</Text>
             {(() => {
               const focus = getFocusTask();
-              if (!focus) return null;
+              if (!focus) {return null;}
               return (
                 <View style={[styles.focusCard, { marginTop: spacing.sm }]}> 
                   <Text style={styles.focusTaskTitle}>{focus.title}</Text>

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -85,6 +85,98 @@ export const goalsAPI = {
     }
   },
 
+  // Create a milestone under a goal
+  createMilestone: async (
+    goalId: string,
+    payload: { title: string; order: number }
+  ): Promise<{ id: string; title: string; order: number; steps: any[] }> => {
+    try {
+      const token = await getAuthToken();
+      const response = await fetch(`${configService.getBaseUrl()}/goals/${goalId}/milestones`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`HTTP error! status: ${response.status}, body: ${text}`);
+      }
+      return await response.json();
+    } catch (error) {
+      console.error('🔍 API: Error creating milestone:', error);
+      throw error;
+    }
+  },
+
+  // Delete a milestone
+  deleteMilestone: async (milestoneId: string): Promise<void> => {
+    try {
+      const token = await getAuthToken();
+      const response = await fetch(`${configService.getBaseUrl()}/goals/milestones/${milestoneId}`, {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`HTTP error! status: ${response.status}, body: ${text}`);
+      }
+    } catch (error) {
+      console.error('🔍 API: Error deleting milestone:', error);
+      throw error;
+    }
+  },
+
+  // Create a step under a milestone
+  createStep: async (
+    milestoneId: string,
+    payload: { text: string; order: number }
+  ): Promise<{ id: string; text: string; order: number }> => {
+    try {
+      const token = await getAuthToken();
+      const response = await fetch(`${configService.getBaseUrl()}/goals/milestones/${milestoneId}/steps`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`HTTP error! status: ${response.status}, body: ${text}`);
+      }
+      return await response.json();
+    } catch (error) {
+      console.error('🔍 API: Error creating step:', error);
+      throw error;
+    }
+  },
+
+  // Delete a step
+  deleteStep: async (stepId: string): Promise<void> => {
+    try {
+      const token = await getAuthToken();
+      const response = await fetch(`${configService.getBaseUrl()}/goals/steps/${stepId}`, {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`HTTP error! status: ${response.status}, body: ${text}`);
+      }
+    } catch (error) {
+      console.error('🔍 API: Error deleting step:', error);
+      throw error;
+    }
+  },
+
   // Create a new goal using real backend
   createGoal: async (goalData: Goal): Promise<Goal> => {
     try {

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -978,7 +978,7 @@ export const usersAPI = {
       method: 'GET',
       headers: { 'Authorization': `Bearer ${token}` },
     });
-    if (!response.ok) throw new Error(await response.text());
+    if (!response.ok) {throw new Error(await response.text());}
     return response.json();
   },
   updateMe: async (payload: Partial<{ full_name: string; avatar_url: string; geographic_location: string; theme_preference: 'light'|'dark'; notification_preferences: any; }>): Promise<any> => {
@@ -988,7 +988,7 @@ export const usersAPI = {
       headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    if (!response.ok) throw new Error(await response.text());
+    if (!response.ok) {throw new Error(await response.text());}
     return response.json();
   }
 };

--- a/mobile/src/services/offline.ts
+++ b/mobile/src/services/offline.ts
@@ -106,7 +106,7 @@ class OfflineService {
   async getCachedEvents(): Promise<CalendarEvent[] | null> {
     try {
       const cached = await AsyncStorage.getItem(STORAGE_KEYS.EVENTS_CACHE);
-      if (!cached) return null;
+      if (!cached) {return null;}
 
       const cacheData: CacheData<CalendarEvent[]> = JSON.parse(cached);
       const isExpired = Date.now() - cacheData.timestamp > CACHE_EXPIRATION;
@@ -135,7 +135,7 @@ class OfflineService {
   async getCachedTasks(): Promise<Task[] | null> {
     try {
       const cached = await AsyncStorage.getItem(STORAGE_KEYS.TASKS_CACHE);
-      if (!cached) return null;
+      if (!cached) {return null;}
 
       const cacheData: CacheData<Task[]> = JSON.parse(cached);
       const isExpired = Date.now() - cacheData.timestamp > CACHE_EXPIRATION;
@@ -164,7 +164,7 @@ class OfflineService {
   async getCachedGoals(): Promise<Goal[] | null> {
     try {
       const cached = await AsyncStorage.getItem(STORAGE_KEYS.GOALS_CACHE);
-      if (!cached) return null;
+      if (!cached) {return null;}
 
       const cacheData: CacheData<Goal[]> = JSON.parse(cached);
       const isExpired = Date.now() - cacheData.timestamp > CACHE_EXPIRATION;
@@ -238,7 +238,7 @@ class OfflineService {
 
   // Sync offline queue when back online
   async syncOfflineQueue(): Promise<void> {
-    if (this.isSyncing || !this.isOnline) return;
+    if (this.isSyncing || !this.isOnline) {return;}
 
     this.isSyncing = true;
     this.notifyListeners();

--- a/mobile/src/utils/dateUtils.ts
+++ b/mobile/src/utils/dateUtils.ts
@@ -172,7 +172,7 @@ export const isThisWeek = (date: Date): boolean => {
  * Check if a task is overdue
  */
 export const isOverdue = (dueDate: Date, status?: string): boolean => {
-  if (status === 'completed') return false;
+  if (status === 'completed') {return false;}
   return dueDate < new Date();
 };
 

--- a/mobile/src/utils/errorRecovery.ts
+++ b/mobile/src/utils/errorRecovery.ts
@@ -92,7 +92,7 @@ class ErrorRecoveryService {
   // Check if circuit breaker should transition to half-open
   private shouldTransitionToHalfOpen(endpoint: string): boolean {
     const state = this.getCircuitBreakerState(endpoint);
-    if (state !== CircuitBreakerState.OPEN) return false;
+    if (state !== CircuitBreakerState.OPEN) {return false;}
 
     const lastFailureTime = this.lastFailureTimes.get(endpoint) || 0;
     const timeSinceLastFailure = Date.now() - lastFailureTime;
@@ -198,7 +198,7 @@ class ErrorRecoveryService {
 
   // Classify error type
   private classifyError(error: any): ErrorType {
-    if (!error) return ErrorType.UNKNOWN;
+    if (!error) {return ErrorType.UNKNOWN;}
 
     const message = error.message || error.toString();
     const status = error.status || error.response?.status || 0;


### PR DESCRIPTION
Summary
- Overall Progress card: shows step completion across active goals and total active count.
- Goals layout: Active, Needs Review (overdue, gentle tone), Completed sections with counts.
- Inline editing:
  - Auto-growing inputs for milestone/step titles.
  - Add/remove milestones and steps with +/−, inline save/cancel.
  - Date edit UX for target date (iOS inline, Android picker).
- AI Assistant:
  - Compact card under Active section, Octicon icon, left-justified copy.
  - Accept & Edit: creates goal and opens inline editor for the new goal.
  - Accept As-Is: creates goal as suggested.
  - Accept Goal Only: creates just the goal, opens inline editor to add structure.
  - Re-do: returns to form and surfaces refinement feedback field to guide revisions.
- Scheduling:
  - “Schedule next step” sends a structured prompt to AI Chat.
  - Schedule options show time and date; tapping creates a calendar event.
  - Titles are truncated for readability.
- Other:
  - Pull-to-refresh on Goals.
  - Status bar/UI styling cleanups for a white header.

Implementation notes
- New API calls in `goalsAPI`: `createMilestone`, `deleteMilestone`, `createStep`, `deleteStep`.
- `ScheduleDisplay`:
  - Robust date parsing for “on Aug 20, 2025” or standalone date lines.
  - Tap-to-schedule via `calendarAPI.createEvent`.
- Accept & Edit flows set inline editor state programmatically for the created goal.
- Debug auth buttons gated by `__DEV__`.

Testing
- TypeScript check: green.
- ESLint: flat config added, warnings only (kept intentionally for pre-alpha).
- Manual smoke:
  - Add/delete milestones/steps; autosize works; Save persists.
  - AI flows: Accept variants and Re-do feedback field.
  - Scheduling: options render with dates; tapping creates event.
  - Pull-to-refresh refreshes goals.

Risk/Follow-ups
- Backend endpoints for new milestone/step APIs must be present.
- Schedule date parsing is resilient; falls back to raw date string if unparseable.
- Optional: tighten ESLint rules later; add unit tests post-alpha.

Screenshots to include
- AI suggestion card with black/gold buttons.
- Inline edit block showing +/− and autosizing inputs.
- Schedule list with time + date and tap-to-schedule behavior.